### PR TITLE
Implement Parallel State Machine Listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Inspired from [@davidkpiano](https://github.com/davidkpiano) X-State library. (m
 Figure from xstate.js.org/viz/
 
 
+##### Basic State Machine
 ```go
 machine := statemachine.Machine{
     ID:      "machine-1",
@@ -38,6 +39,24 @@ output := machine.Transition("TOGGLE")
 // after sending TOGGLE event
 ```
 
+##### Parallel Machine
+You can also build a parallel state machine, that bundles up multiple state machines together. 
+```go
+parallel := statemachine.ParallelMachine{
+    Machines: statemachine.Machines{
+        "machine-1": &machineOne,
+        "machine-2": &machineTwo,
+    },
+    Subscribers: statemachine.ParallelSubscribers{
+        // some state subscribers
+    },
+}
+
+// Send machine-1 TOGGLE state  
+next, err := parallel.Transition("machine-1.TOGGLE")
+```
+
+
 ##### Checklist
 
 - [x] Implement basic finite state machine with transition
@@ -45,4 +64,4 @@ output := machine.Transition("TOGGLE")
 - [x] Add multiple actions and call the function on state change.
 - [x] Add state change listeners.  
 - [x] Support for parallel state machines.
-- [ ] Implement Parallel State machines state listeners.
+- [x] Implement Parallel State machines state listeners.

--- a/parallel.go
+++ b/parallel.go
@@ -5,14 +5,26 @@ import (
 	"strings"
 )
 
+// Machines bundle up multiple state machine definitions
+type Machines map[string]IMachine
+
+// ParallelState describes parallel state machines state
+type ParallelState map[string]string
+
+// ParallelSubscribers type declaration for parallel machine subscribers
+type ParallelSubscribers []func(ParallelState, ParallelState)
+
 // ParallelMachine to start a parallel state machine
-type ParallelMachine map[string]IMachine
+type ParallelMachine struct {
+	Machines    Machines
+	Subscribers []func(curr, next ParallelState)
+}
 
 // Current returns current state of parallel machines
-func (m *ParallelMachine) Current() map[string]string {
-	currentStateMap := make(map[string]string)
-	for machine := range *m {
-		currentStateMap[machine] = (*m)[machine].Current()
+func (m *ParallelMachine) Current() ParallelState {
+	currentStateMap := make(ParallelState)
+	for machine := range (*m).Machines {
+		currentStateMap[machine] = (*m).Machines[machine].Current()
 	}
 	return currentStateMap
 }
@@ -20,14 +32,18 @@ func (m *ParallelMachine) Current() map[string]string {
 // Transition transitions to next state.
 // event format is
 //  m.Transition("machinekey.eventName")
-func (m *ParallelMachine) Transition(event string) (map[string]string, error) {
+func (m *ParallelMachine) Transition(event string) (ParallelState, error) {
 	s := strings.Split(event, ".")
 	if len(s) != 2 {
 		return m.Current(), errors.New("event format doesn't match")
 	}
 
-	if _, ok := (*m)[s[0]]; ok {
-		(*m)[s[0]].Transition(s[1])
+	if _, ok := (*m).Machines[s[0]]; ok {
+		current := m.Current()
+		(*m).Machines[s[0]].Transition(s[1])
+		for _, funct := range (*m).Subscribers {
+			funct(current, m.Current())
+		}
 		return m.Current(), nil
 	}
 

--- a/parallel_test.go
+++ b/parallel_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestParallelToggle(t *testing.T) {
+	times := 0
 	machineOne := statemachine.Machine{
 		ID:      "machine-1",
 		Initial: "on",
@@ -51,18 +52,26 @@ func TestParallelToggle(t *testing.T) {
 	}
 
 	parallel := statemachine.ParallelMachine{
-		"machine-1": &machineOne,
-		"machine-2": &machineTwo,
+		Machines: statemachine.Machines{
+			"machine-1": &machineOne,
+			"machine-2": &machineTwo,
+		},
+		Subscribers: statemachine.ParallelSubscribers{
+			func(c, n statemachine.ParallelState) { times++ },
+			func(c, n statemachine.ParallelState) { times++ },
+			func(c, n statemachine.ParallelState) { times++ },
+		},
 	}
 
 	next, err := parallel.Transition("machine-1.TOGGLE")
-	assert.Equal(t, map[string]string{"machine-1": "off", "machine-2": "on"}, next, "Transition should occur on toggle.")
+	assert.Equal(t, statemachine.ParallelState{"machine-1": "off", "machine-2": "on"}, next, "Transition should occur on toggle.")
 	assert.Equal(t, nil, err, "Error should not occurr in correct transition")
+	assert.Equal(t, 3, times, "Subscribers should be called on transition")
 
 	next, err = parallel.Transition("machine-one")
 	if assert.Error(t, err) {
 		assert.Equal(t, errors.New("event format doesn't match"), err)
-		assert.Equal(t, next, map[string]string{"machine-1": "off", "machine-2": "on"}, "Transition should not occur on error.")
+		assert.Equal(t, next, statemachine.ParallelState{"machine-1": "off", "machine-2": "on"}, "Transition should not occur on error.")
 	} else {
 		t.Error("error should occurr when key format doesn't match")
 	}
@@ -70,8 +79,10 @@ func TestParallelToggle(t *testing.T) {
 	next, err = parallel.Transition("machine-one.TOGGLE")
 	if assert.Error(t, err) {
 		assert.Equal(t, errors.New("machine key doesnot match"), err)
-		assert.Equal(t, next, map[string]string{"machine-1": "off", "machine-2": "on"}, "Transition should not occur on error.")
+		assert.Equal(t, next, statemachine.ParallelState{"machine-1": "off", "machine-2": "on"}, "Transition should not occur on error.")
 	} else {
 		t.Error("error should occurr when machine key doesnot exist")
 	}
+
+	assert.Equal(t, 3, times, "Subscribers shouldnot be called on error on transition")
 }


### PR DESCRIPTION
#### What this pull request contains:
- 0abd749 Adds parallel machine listeners using `Subscribers` and minor adjustments to parallel machine definitions. 
```go
parallel := statemachine.ParallelMachine{
    Machines: statemachine.Machines{
        "machine-1": &machineOne,
        "machine-2": &machineTwo,
    },
    Subscribers: statemachine.ParallelSubscribers{
        // some state subscribers
    },
}
```
- 4ec69de Adds documentation for creating and transitioning parallel machine.